### PR TITLE
fix: improve console output for files specified by URL

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -90,6 +90,8 @@ if (!manifestFile) {
 }
 
 inquireParams({ username, password, domain, lang })
-  .then(({ username, password, domain }) => {
-    run(domain, username, password, manifestFile, options);
-  });
+  .then(({ username, password, domain }) => (
+    run(domain, username, password, manifestFile, options)
+  ))
+  .catch(error => console.log(error.message));
+  ;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ async function upload(
 
   try {
     if (!updateBody) {
+      console.log(m("M_StartUploading"));
       try {
         const [desktopJS, desktopCSS, mobileJS] = await Promise.all(
           [
@@ -54,7 +55,9 @@ async function upload(
                 kintoneApiClient
                   .prepareCustomizeFile(file, type)
                   .then(result => {
-                    console.log(`${file} ` + m("M_Uploaded"));
+                    if (result.type === "FILE") {
+                      console.log(`${file} ` + m("M_Uploaded"));
+                    }
                     return result;
                   })
               )
@@ -102,7 +105,7 @@ async function upload(
     const isAuthenticationError = e instanceof AuthenticationError;
     retryCount++;
     if (isAuthenticationError) {
-      console.log(m("E_Authentication"));
+      throw new Error(m("E_Authentication"));
     } else if (retryCount < MAX_RETRY_COUNT) {
       await wait(1000);
       console.log(m("E_Retry"));
@@ -113,7 +116,7 @@ async function upload(
         options
       );
     } else {
-      console.log(e.message);
+      throw e;
     }
   }
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -20,6 +20,10 @@ const messages = {
     en: "Input your password:",
     ja: "パスワードを入力してください:"
   },
+  M_StartUploading: {
+    en: "Start uploading customize files",
+    ja: "カスタマイズのアップロードを開始します"
+  },
   M_FileUploaded: {
     en: "JavaScript/CSS files have been uploaded!",
     ja: "JavaScript/CSS ファイルをアップロードしました!"


### PR DESCRIPTION
`customize-uploader` doesn't upload files specified by URL, but the following log is printed.

```
https://example.com/a.js has been uploaded!
```

This PR stops printing the log.
In addition to that, I've added a message for telling to start uploading files, which is useful in slow network environments.