### PR TITLE
[WIP] feat: reupload only a modified file

### DIFF
--- a/src/CustomizeFileStatus.ts
+++ b/src/CustomizeFileStatus.ts
@@ -1,0 +1,56 @@
+import fs from "fs";
+
+import { CustomizeManifest, CustomizeSetting } from "./KintoneApiClient";
+import { isUrlString } from "./util";
+
+interface FileStatus {
+  target: "mobile" | "pc";
+  type: "js" | "css";
+  index: number;
+  mtime: number;
+  fileKey: string | null;
+}
+
+export default class CustomizeFileStatus {
+  private fileStatuses: FileStatus[];
+  constructor(manifest: CustomizeManifest) {
+    this.fileStatuses = [
+      ...manifest.desktop.js.map((filePath, index) =>
+        this.createFileStatus("pc", "js", index, filePath)
+      ),
+      ...manifest.desktop.css.map((filePath, index) =>
+        this.createFileStatus("pc", "css", index, filePath)
+      ),
+      ...manifest.mobile.js.map((filePath, index) =>
+        this.createFileStatus("mobile", "js", index, filePath)
+      )
+    ];
+    console.log(this.fileStatuses);
+  }
+  public setFileKey(customizeSetting: CustomizeSetting): void {
+    // TODO
+  }
+
+  public canSkipUpload(): boolean {
+    return false;
+  }
+
+  public getFileKey(target: string, type: string, index: number): string {
+    return "todo";
+  }
+
+  private createFileStatus(
+    target: "mobile" | "pc",
+    type: "js" | "css",
+    index: number,
+    filePath: string
+  ): FileStatus {
+    return {
+      target,
+      type,
+      index,
+      mtime: isUrlString(filePath) ? 0 : +fs.statSync(filePath).mtime,
+      fileKey: null
+    };
+  }
+}

--- a/src/KintoneApiClient.ts
+++ b/src/KintoneApiClient.ts
@@ -6,12 +6,24 @@ interface RequestOption {
   method: string;
   url: string;
   headers: {
-    [propName: string]: any;
+    [propName: string]: string;
   };
   body: object | string | null;
   formData?: object;
   proxy?: string;
   tunnel?: boolean;
+}
+
+export interface CustomizeManifest {
+  app: string;
+  scope: "ALL" | "ADMIN" | "NONE";
+  desktop: {
+    js: string[];
+    css: string[];
+  };
+  mobile: {
+    js: string[];
+  };
 }
 
 export interface Option {
@@ -25,6 +37,18 @@ export interface RequestParams {
   body: object;
   contentType?: string;
 }
+
+type ReturnedCustomizeSetting =
+  | {
+      type: "URL";
+      url: string;
+    }
+  | {
+      type: "FILE";
+      file: {
+        fileKey: string;
+      };
+    };
 
 export default class KintoneApiClient {
   private auth: string;
@@ -64,7 +88,7 @@ export default class KintoneApiClient {
   public async prepareCustomizeFile(
     fileOrUrl: string,
     contentType: string
-  ): Promise<any> {
+  ): Promise<ReturnedCustomizeSetting> {
     const isUrl = isUrlString(fileOrUrl);
     if (isUrl) {
       return {
@@ -82,7 +106,7 @@ export default class KintoneApiClient {
     }
   }
 
-  public updateCustomizeSetting(setting: any) {
+  public updateCustomizeSetting(setting: CustomizeManifest) {
     return this.sendRequest({
       method: "PUT",
       path: "/k/v1/preview/app/customize.json",
@@ -106,7 +130,10 @@ export default class KintoneApiClient {
         path: "/k/v1/preview/app/deploy.json",
         body: { apps: [appId] }
       });
-      const successedApps: [any] = resp.apps;
+      interface App {
+        status: string;
+      }
+      const successedApps: App[] = resp.apps;
       const successedAppsLength = successedApps.filter(r => {
         return r.status === "SUCCESS";
       }).length;

--- a/src/KintoneApiClient.ts
+++ b/src/KintoneApiClient.ts
@@ -38,17 +38,29 @@ export interface RequestParams {
   contentType?: string;
 }
 
-type ReturnedCustomizeSetting =
-  | {
-      type: "URL";
-      url: string;
-    }
-  | {
-      type: "FILE";
-      file: {
-        fileKey: string;
-      };
-    };
+export interface CustomizeSetting {
+  desktop: {
+    js: ReturnedCustomizeSetting[];
+    css: ReturnedCustomizeSetting[];
+  };
+  mobile: {
+    js: ReturnedCustomizeSetting[];
+  };
+}
+
+export interface FileCustomizeSetting {
+  type: "FILE";
+  file: {
+    fileKey: string;
+  };
+}
+
+interface URLCustomizeSetting {
+  type: "URL";
+  url: string;
+}
+
+type ReturnedCustomizeSetting = FileCustomizeSetting | URLCustomizeSetting;
 
 export default class KintoneApiClient {
   private auth: string;
@@ -144,6 +156,14 @@ export default class KintoneApiClient {
       }
     }
     deployed = true;
+  }
+
+  public async getCustomizeSetting(app: string): Promise<CustomizeSetting> {
+    return this.sendRequest({
+      method: "GET",
+      path: "/k/v1/app/customize.json",
+      body: { app }
+    });
   }
 
   public async sendRequest(params: RequestParams) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import chokidar from "chokidar";
 import fs from "fs";
-import KintoneApiClient, { AuthenticationError } from "./KintoneApiClient";
+import KintoneApiClient, {
+  AuthenticationError,
+  CustomizeManifest
+} from "./KintoneApiClient";
 import { Lang } from "./lang";
 import { getBoundMessage } from "./messages";
 import { isUrlString, wait } from "./util";
@@ -14,20 +17,8 @@ export interface Option {
 
 export interface Status {
   retryCount: number;
-  updateBody: any;
+  updateBody: CustomizeManifest | null;
   updated: boolean;
-}
-
-export interface CustomizeManifest {
-  app: string;
-  scope: "ALL" | "ADMIN" | "NONE";
-  desktop: {
-    js: string[];
-    css: string[];
-  };
-  mobile: {
-    js: string[];
-  };
 }
 
 const MAX_RETRY_COUNT = 3;
@@ -37,7 +28,7 @@ export async function upload(
   manifest: CustomizeManifest,
   status: {
     retryCount: number;
-    updateBody: any;
+    updateBody: CustomizeManifest | null;
     updated: boolean;
   },
   options: Option

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
-import { CustomizeManifest, Option, Status, upload } from "../src/index";
+import { Option, Status, upload } from "../src/index";
+import { CustomizeManifest } from "../src/KintoneApiClient";
 import MockKintoneApiClient from "./MockKintoneApiClient";
 
 describe("index", () => {


### PR DESCRIPTION
Fix #6 
This is a naive approach that depends on `chokidar`, which might not work in some environments.
So I might change the implementation to compare a file hash on change events of `chokidar`.

## Test

- [ ] macOS
- [ ] Windows