### PR TITLE
fix: support an old customize-manifest.json format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,9 @@ export const run = async (
     updated: false
   };
 
+  // support an old format for customize-manifest.json that doesn't have mobile.css
+  manifest.mobile.css = manifest.mobile.css || [];
+
   const files = manifest.desktop.js
     .concat(manifest.desktop.css, manifest.mobile.js, manifest.mobile.css)
     .filter((fileOrPath: string) => !isUrlString(fileOrPath));


### PR DESCRIPTION
A format for `customize-manifest.json` might not have `mobile.css` field because the filed has been supported recently so I've added the old format.