### PR TITLE
use Buffer.from instead of new Buffer

### DIFF
--- a/src/KintoneApiClient.ts
+++ b/src/KintoneApiClient.ts
@@ -204,7 +204,7 @@ export default class KintoneApiClient {
     username: string,
     password: string
   ): string {
-    const buffer = new Buffer(username + ":" + password);
+    const buffer = Buffer.from(username + ":" + password);
     return buffer.toString("base64");
   }
 


### PR DESCRIPTION
> (node:70005) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.