### PR TITLE
Fix `isUrlString` logic

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,5 @@
 export function isUrlString(str: string): boolean {
-  return /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/i.test(
-    str
-  );
+  return /https?:\/\/.*/i.test(str);
 }
 
 export async function wait(ms: number): Promise<void> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 export function isUrlString(str: string): boolean {
-  return /https?:\/\/.*/i.test(str);
+  return /^https?:\/\/.*/i.test(str);
 }
 
 export async function wait(ms: number): Promise<void> {

--- a/test/util-test.ts
+++ b/test/util-test.ts
@@ -5,9 +5,11 @@ describe("util", () => {
   describe("isUrlString", () => {
     it("should return true if the string is URL", () => {
       assert(isUrlString("https://example.com") === true);
+      assert(isUrlString("http://localhost:8000") === true);
     });
     it("should return false if the string is not URL", () => {
       assert(isUrlString("example.com") === false);
+      assert(isUrlString("js/desktop.js") === false);
     });
   });
 


### PR DESCRIPTION
Change `isUrlString()` logic so that the string like `https://localhost:8000/...` is judged as URL.